### PR TITLE
[WIP] Expo build github action

### DIFF
--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -1,0 +1,35 @@
+name: Expo EAS Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/expo/**'
+      - 'packages/ui/**'
+      - 'packages/app/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: yarn
+
+      - name: 🏗 Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 📦 Install dependencies
+        run: yarn install
+
+      - name: 🚀 Build app
+        run: eas build --non-interactive

--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -13,23 +13,28 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: 🏗 Setup repo
+      - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
-      - name: 🏗 Setup Node
+      - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
-          cache: yarn
+          node-version: 18
+          cache: 'yarn'
 
-      - name: 🏗 Setup EAS
+      - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: 📦 Install dependencies
-        run: yarn install
+      - name: Install dependencies
+        uses: borales/actions-yarn@v4.2.0
+        with:
+          cmd: install
+          dir: apps/expo
 
-      - name: 🚀 Build app
+      - name: Build app
         run: eas build --non-interactive

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ yarn create t4-app --supabase
 
 I would like to add the following features to `create-t4-app` in the future:
 
-- [ ] Github Action publishing for Expo apps
+- ✅ Github Action publishing for Expo apps
 - ✅ Database migration in CI/CD
 - [ ] GraphQL (type-safe) data fetching
   - ⏲️ [GQty](https://gqty.dev) - A No-GraphQL client for TypeScript.

--- a/apps/docs/pages/workflow/production.mdx
+++ b/apps/docs/pages/workflow/production.mdx
@@ -28,12 +28,6 @@ CF_PROJECT_NAME=
 
 2. Disable `Enable automatic production branch deployments` in the Cloudflare Pages dashboard. This conflicts with our Github Actions.
 
-#### 📱 Expo
-
-```bash
-TODO=
-```
-
 ## Configure Wrangler.toml
 
 > Wrangler is the official CLI tool for Cloudflare Workers.
@@ -69,6 +63,12 @@ route = "app.t4stack.com/*"
 workers_dev = false
 ```
 
+#### 📱 Expo
+
+1. Go in your [Expo settings](https://expo.dev/accounts/%5Baccount%5D/settings/access-tokens) to create a new access token.
+
+2. Add the `EXPO_TOKEN` secret to your repository with the token that you retrieved from Expo to allow GitHub Actions to publish your app.
+
 ## Environment Variables
 
 Configure environment variables within the Cloudflare Pages dashboard for production.
@@ -90,7 +90,7 @@ CLERK_SECRET_KEY=
 ## Authentication - Supabase
 
 To set up authentication with Supabase in your application, you will need to configure certain environment
-variables and customize the email verification redirect link for production. 
+variables and customize the email verification redirect link for production.
 Head over to [](https://supabase.com/dashboard) for your Supabase API keys and set the following environment variables:
 
 ```bash
@@ -109,4 +109,3 @@ To set up the email verification redirect link, follow these steps:
 - Enter the URL of your production website that you want users to be redirected to.
 
 By customizing this redirect link, you ensure a seamless experience for your users during the email verification process.
-


### PR DESCRIPTION
This should be the code necessary for setting up an EAS build on push, tweaked to look similar to the other github actions.

It caches automatically with [@actions/cache](https://github.com/actions/toolkit/tree/main/packages/cache) under the hood.