### PR TITLE
[WIP] [Feature] Supabase password reset

### DIFF
--- a/apps/expo/app/password-reset/index.tsx
+++ b/apps/expo/app/password-reset/index.tsx
@@ -1,0 +1,5 @@
+import { PasswordResetScreen } from 'app/features/password-reset/screen'
+
+export default function () {
+  return <PasswordResetScreen />
+}

--- a/apps/expo/app/password-reset/update-password/index.tsx
+++ b/apps/expo/app/password-reset/update-password/index.tsx
@@ -1,0 +1,5 @@
+import { UpdatePasswordScreen } from 'app/features/password-reset/update-password/screen'
+
+export default function () {
+  return <UpdatePasswordScreen />
+}

--- a/apps/next/pages/password-reset/index.tsx
+++ b/apps/next/pages/password-reset/index.tsx
@@ -1,0 +1,13 @@
+import Head from 'next/head'
+import { PasswordResetScreen } from 'app/features/password-reset/screen'
+
+export default function Page() {
+  return (
+    <>
+      <Head>
+        <title>Password Reset</title>
+      </Head>
+      <PasswordResetScreen />
+    </>
+  )
+}

--- a/apps/next/pages/password-reset/update-password/index.tsx
+++ b/apps/next/pages/password-reset/update-password/index.tsx
@@ -1,0 +1,13 @@
+import Head from 'next/head'
+import { UpdatePasswordScreen } from 'app/features/password-reset/update-password/screen'
+
+export default function Page() {
+  return (
+    <>
+      <Head>
+        <title>Password Reset</title>
+      </Head>
+      <UpdatePasswordScreen />
+    </>
+  )
+}

--- a/packages/app/features/password-reset/screen.tsx
+++ b/packages/app/features/password-reset/screen.tsx
@@ -1,0 +1,25 @@
+import { YStack } from '@t4/ui'
+import { useRouter } from 'solito/router'
+import { PasswordResetComponent } from '@t4/ui/src/PasswordReset'
+import { sendPasswordResetEmail } from 'app/utils/supabase/auth'
+
+export function PasswordResetScreen() {
+  const { push } = useRouter()
+
+  const handleEmailWithPress = async (emailOrPassword) => {
+    // Email for the password reset
+    const { error } = await sendPasswordResetEmail(emailOrPassword)
+    if (error) {
+      console.log('Password reset request failed', error)
+      return
+    }
+
+    push('/')
+  }
+
+  return (
+    <YStack f={1} jc="center" ai="center" space>
+      <PasswordResetComponent type="email" handleWithPress={handleEmailWithPress} />
+    </YStack>
+  )
+}

--- a/packages/app/features/password-reset/update-password/screen.tsx
+++ b/packages/app/features/password-reset/update-password/screen.tsx
@@ -1,0 +1,25 @@
+import { YStack } from '@t4/ui'
+import { useRouter } from 'solito/router'
+import { PasswordResetComponent } from '@t4/ui/src/PasswordReset'
+import { updatePassword } from 'app/utils/supabase/auth'
+
+export function UpdatePasswordScreen() {
+  const { push } = useRouter()
+
+  const handlePasswordWithPress = async (emailOrPassword) => {
+    // Update the password
+    const { error } = await updatePassword(emailOrPassword)
+    if (error) {
+      console.log('Password change failed', error)
+      return
+    }
+
+    push('/')
+  }
+
+  return (
+    <YStack f={1} jc="center" ai="center" space>
+      <PasswordResetComponent type="password" handleWithPress={handlePasswordWithPress} />
+    </YStack>
+  )
+}

--- a/packages/app/utils/supabase/auth.ts
+++ b/packages/app/utils/supabase/auth.ts
@@ -55,7 +55,7 @@ const signOut = async () => {
 
 const sendPasswordResetEmail = async (email) => {
   const { data, error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: 'http://localhost:3000/password-reset/update-password',
+    redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/password-reset/update-password`,
   })
   return { data, error }
 }

--- a/packages/app/utils/supabase/auth.ts
+++ b/packages/app/utils/supabase/auth.ts
@@ -53,6 +53,20 @@ const signOut = async () => {
   await supabase.auth.signOut()
 }
 
+const sendPasswordResetEmail = async (email) => {
+  const { data, error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: 'http://localhost:3000/password-reset/update-password',
+  })
+  return { data, error }
+}
+
+const updatePassword = async (newPassword) => {
+  const { data, error } = await supabase.auth.updateUser({
+    password: newPassword,
+  })
+  return { data, error }
+}
+
 const getUser = async () => {
   const {
     data: { user },
@@ -85,4 +99,14 @@ const isUserSignedIn = async () => {
   return session !== null && session.user !== null
 }
 
-export { supabase, signIn, signInWithOAuth, signUp, signOut, getUser, isUserSignedIn }
+export {
+  supabase,
+  signIn,
+  signInWithOAuth,
+  sendPasswordResetEmail,
+  updatePassword,
+  signUp,
+  signOut,
+  getUser,
+  isUserSignedIn,
+}

--- a/packages/ui/src/PasswordReset.tsx
+++ b/packages/ui/src/PasswordReset.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+import { YStack, Paragraph, Button, Input } from 'tamagui'
+
+interface Props {
+  type: 'email' | 'password'
+  handleWithPress: (emailOrPassword) => void
+}
+
+export const PasswordResetComponent: React.FC<Props> = ({ type, handleWithPress }) => {
+  const [emailOrPassword, setEmailOrPassword] = useState('')
+
+  return (
+    <YStack
+      borderRadius="$10"
+      space
+      px="$7"
+      py="$6"
+      w={350}
+      shadowColor={'#00000020'}
+      shadowRadius={26}
+      shadowOffset={{ width: 0, height: 4 }}
+      bg="$background"
+    >
+      <Paragraph size="$5" fontWeight={'700'} opacity={0.8} mb="$1">
+        {type == 'email' ? 'Reset your password' : 'Change your password'}
+      </Paragraph>
+
+      {/* email or password input */}
+
+      {type === 'email' ? (
+        <Input
+          autoCapitalize="none"
+          placeholder="Email"
+          onChangeText={(text) => {
+            setEmailOrPassword(text)
+          }}
+        />
+      ) : (
+        <Input
+          autoCapitalize="none"
+          placeholder="New Password"
+          onChangeText={(text) => {
+            setEmailOrPassword(text)
+          }}
+          textContentType="password"
+          secureTextEntry
+        />
+      )}
+
+      {/* reset password button */}
+      <Button
+        themeInverse
+        onPress={() => {
+          handleWithPress(emailOrPassword)
+        }}
+        hoverStyle={{ opacity: 0.8 }}
+        onHoverIn={() => {}}
+        onHoverOut={() => {}}
+        focusStyle={{ scale: 0.975 }}
+      >
+        {type == 'email' ? 'Reset Password' : 'Change Password'}
+      </Button>
+    </YStack>
+  )
+}

--- a/packages/ui/src/SignUpSignIn.tsx
+++ b/packages/ui/src/SignUpSignIn.tsx
@@ -141,6 +141,26 @@ export const SignUpSignInComponent: React.FC<Props> = ({
           </Paragraph>
         </Link>
       </XStack>
+
+      {/* forgot password */}
+      {type === 'sign-in' && (
+        <XStack mt="$-2.5">
+          <Paragraph size="$2" mr="$2" opacity={0.4}>
+            Forgot your password?
+          </Paragraph>
+          <Link href="/password-reset">
+            <Paragraph
+              cursor={'pointer'}
+              size="$2"
+              fontWeight={'700'}
+              opacity={0.5}
+              hoverStyle={{ opacity: 0.4 }}
+            >
+              Reset it
+            </Paragraph>
+          </Link>
+        </XStack>
+      )}
     </YStack>
   )
 }


### PR DESCRIPTION
I've implemented a simple password reset for supabase. This inclued two new pages `/password-reset` and `/password-reset/update-password` respectively to send the password reset email and to update the users password once received the token. I also added a link in `/sign-in` to the password reset page.

To set it up add a new redirect URL to your supabase dashboard under **Authentication > URL Configuration** as `http://localhost:3000/password-reset/update-password`. 
This is the same url used in `auth.ts` so in production you wanna change the `NEXT_PUBLIC_APP_URL` environment variable.
I'll document that in the docs once this gets done properly.

Needs some testing for the redirects on all platforms.