### PR TITLE
[Feature] Updated expo workflow to include links and QRs

### DIFF
--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -1,4 +1,4 @@
-name: Expo Deployment
+name: Expo Build
 
 on:
   workflow_dispatch:
@@ -9,6 +9,13 @@ on:
       - 'apps/expo/**'
       - 'packages/ui/**'
       - 'packages/app/**'
+
+permissions:
+  contents: write
+
+env:
+  BUILD_PROFILE: development
+  # BUILD_PROFILE: production
 
 jobs:
   build:
@@ -38,4 +45,31 @@ jobs:
           dir: apps/expo
 
       - name: Build app
-        run: 'cd apps/expo && eas build --non-interactive --no-wait --platform all --profile production'
+        id: build
+        continue-on-error: true
+        run: |
+          cd apps/expo && build_json=$(eas build --profile $BUILD_PROFILE --platform all --non-interactive --json)
+          android_link=$(echo $build_json | jq -r '.[] | select(.platform=="ANDROID") | .artifacts.applicationArchiveUrl')
+          ios_link=$(echo $build_json | jq -r '.[] | select(.platform=="IOS") | .artifacts.applicationArchiveUrl')
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "build_json<<$EOF" >> $GITHUB_OUTPUT
+          echo "$build_json" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+          echo "android=$android_link" >> $GITHUB_OUTPUT
+          echo "ios=$ios_link" >> $GITHUB_OUTPUT
+
+      - name: Comment commit
+        if: github.event_name == 'push'
+        uses: peter-evans/commit-comment@v2
+        with:
+          body: |
+            ✔ EAS ${{ env.BUILD_PROFILE }} build completed
+            - 🤖 Android ${{ steps.build.outputs.android != '' && '[build download][1]' || 'build failed ❌' }}
+            - 🍏 IOS ${{ steps.build.outputs.ios != '' && '[build download][2]' || 'build failed ❌' }}
+
+            ${{ steps.build.outputs.android != '' && format('| [![Android QR](https://api.qrserver.com/v1/create-qr-code/?data={0}&bgcolor=CAFFE1&margin=10)](#void)', steps.build.outputs.android) || '| ❌' }} ${{ steps.build.outputs.ios != '' && format('| [![IOS QR](https://api.qrserver.com/v1/create-qr-code/?data={0}&bgcolor=CFE6FF&margin=10)](#void) |', steps.build.outputs.ios) || '| ❌ |' }}
+            | :------------: | :--------: |
+            | **Android QR** | **IOS QR** |
+
+            ${{ steps.build.outputs.android != '' && format('[1]: {0}', steps.build.outputs.android) }}
+            ${{ steps.build.outputs.ios != '' && format('[2]: {0}', steps.build.outputs.ios) }}


### PR DESCRIPTION
I updated the expo workflow to output links and QRs in a comment on the commit that pushed the relevant changes. After the build has finished it looks like this:

![2023-07-11 13_24_11-Update package json · albbus-stack_t4-app@022ba28 — Firefox Nightly](https://github.com/timothymiller/t4-app/assets/57916483/11130bba-f482-47fe-a54e-f640ee4d56a5)

You can find it live [here](https://github.com/albbus-stack/t4-app/commit/022ba28c48e33ae5719094682f863ea6dec5a627#commitcomment-121272063).

@timothymiller For this to work you have to set `Read and write permissions` in `Settings > Actions > General > Workflow Permissions`, this specific workflow includes only the `contents: write` permission. 

Currently the `BUILD_PROFILE` variable in the workflow is set to devlopment because in the main repo we don't want app bundles.
I think you should generate the credentials with `eas credentials` if you didn't already but I'm not so sure if this applies to the `development` profile. 

Finally you can change the visibility of your linked `t4-app` expo project to be public so that the links are accessible to everyone. 