### PR TITLE
Prevent file removal errors during project creation

### DIFF
--- a/apps/docs/pages/workflow/production.mdx
+++ b/apps/docs/pages/workflow/production.mdx
@@ -38,7 +38,9 @@ CF_PROJECT_NAME=
 
 4. Setup EAS credentials for your Android and IOS apps by running `eas credentials` in your terminal. Setup the correct `android.package` and `ios.bundleIdentifier` in `apps/expo/app.json`.
 
-5. Push your changes to GitHub and watch your app being built and published to Expo.
+5. Over on your repository set the `Read and write permissions` in `Settings > Actions > General > Workflow Permissions`. This specific workflow includes only the `contents: write` permission that is needed to comment on your commits with the build download links.
+
+6. Push your changes to GitHub and watch your app being built in EAS.
 
 ## Configure Wrangler.toml
 


### PR DESCRIPTION
## Overview:
This pull request makes a modification to the file removal commands in the `apps/cli/bin/index.js` script to prevent errors when the files or directories do not exist.

## Details:
In the `setup` function in `apps/cli/bin/index.js`, the `rm` command was updated to use the `-f` (force) option. This change applies to the removal of `.github/workflows/cli.yml`, `.github/workflows/docs.yml`, and `.github/workflows/vscode.yml` files. The `-f` option will prevent the `rm` command from throwing an error if the file does not exist, allowing the script to continue its execution.

## Reason:
The original script used the `rm -rf` command for both file and directory removal. However, this can lead to errors when a file does not exist because `rm -rf` is primarily intended for directory operations. 

This pull request modifies the script to use `rm -f` for file removal and `rm -rf` for directories. This ensures that the script runs smoothly even if certain files don't exist. 

This specific change addresses an issue encountered when creating a new T4 project with `yarn create t4-app --supabase`, improving the overall user experience by preventing unnecessary errors and interruptions.

## Test Plan:
To test the changes, follow these steps:
1. Pull the changes from this PR.
2. Navigate to the `bin` directory with the command `cd apps/cli/bin`.
3. Run `yarn install` to install any necessary dependencies.
4. Run the script directly using Node.js with the command `node index.js --supabase`.
5. The script should execute successfully without any errors related to the removal of non-existent files.