### PR TITLE
Prevent file removal error -supabase flag

### DIFF
--- a/apps/cli/bin/index.js
+++ b/apps/cli/bin/index.js
@@ -38,7 +38,7 @@ const setup = (folderName) => {
 
       gitSpinner.succeed();
 
-      exec(`rm -rf ${folderName}/cli && rm -rf ${folderName}/.git && rm ${folderName}/.github/workflows/cli.yml`, (rmErr) => {
+      exec(`rm -rf ${folderName}/cli && rm -rf ${folderName}/.git && rm -f ${folderName}/.github/workflows/cli.yml`, (rmErr) => {
         if (rmErr) {
           console.error(
             chalk.red.bold(`Failed to remove unnecessary files: ${rmErr.message}`)


### PR DESCRIPTION
 pull request modifies the script to use rm -f for file removal and rm -rf for directories. This ensures that the script runs smoothly even if certain files don't exist.