### PR TITLE
Omitting the patch version in engines in the package.json file

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -49,7 +49,7 @@ runs:
       with:
         run_install: false
         # If you're not setting the packageManager field in package.json, add the version here
-        # version: 8.6.7
+        # version: 8.6.0
 
     - name: Expose pnpm config(s) through "$GITHUB_OUTPUT"
       id: pnpm-config

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Build native apps for iOS, Android, macOS, Windows, and Linux using the same cod
 
 ## 🚀 Quick Start
 
-> pnpm v8.6.5 is required to use `create-t4-app`
+> pnpm v8.6 is required to use `create-t4-app`
 
 <p align="left">
   <a href="https://pnpm.io">

--- a/apps/docs/pages/getting-started.mdx
+++ b/apps/docs/pages/getting-started.mdx
@@ -1,6 +1,6 @@
 ## 🚀 Getting Started
 
-> pnpm v8.6.5 is required to use `create-t4-app`
+> pnpm v8.6 is required to use `create-t4-app`
 
 To scaffold an app using `create-t4-app`, run any of the following commands.
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node": ">=18.16",
     "pnpm": ">=8.6"
   },
-  "packageManager": "pnpm@8.6.0",
+  "packageManager": "pnpm@8.6.5",
   "pnpm": {
     "overrides": {
       "react-refresh": "~0.14.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node": ">=18.16",
     "pnpm": ">=8.6"
   },
-  "packageManager": "pnpm@8.6.5",
+  "packageManager": "pnpm@8.6.0",
   "pnpm": {
     "overrides": {
       "react-refresh": "~0.14.0"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "typescript": "^5.1.6"
   },
   "engines": {
-    "node": ">=18.16.0",
-    "pnpm": ">=8.6.9"
+    "node": ">=18.16",
+    "pnpm": ">=8.6"
   },
   "packageManager": "pnpm@8.6.5",
   "pnpm": {


### PR DESCRIPTION
Since pnpm versions are changing rapidly and it happens that the version in GitHub actions is not always up to date, it is better to define only major and minor versions.

I have set it for both engines, node and pnpm.

Extract from the workflow log:
```
Run pnpm install --frozen-lockfile --prefer-offline
ERR_PNPM_UNSUPPORTED_ENGINE Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/home/runner/work/t4-app/t4-app".

Expected version: >=8.6.9
Got: 8.6.5

This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.

To install the latest version of pnpm, run "pnpm i -g pnpm".
To check your pnpm version, run "pnpm -v".
Error: Process completed with exit code 1.
```