### PR TITLE
Update docs for using tauri

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ pnpm create t4-app
 If you would like to use Tauri use:
 
 ```bash
-pnpm create t4-app --tauri
+pnpm create t4-app yourappname --tauri
 ```
 
 ## 🧩 VSCode Extension

--- a/apps/docs/pages/getting-started.mdx
+++ b/apps/docs/pages/getting-started.mdx
@@ -15,5 +15,5 @@ pnpm create t4-app
 If you would like to use Tauri use:
 
 ```bash
-pnpm create t4-app --tauri
+pnpm create t4-app yourappname --tauri
 ```


### PR DESCRIPTION
These changes prevent the error when not providing an application name: 🚫 Error: Failed to clone repository: Command failed: git clone  https://github.com/timothymiller/t4-app --tauri error: unknown option `tauri'