### PR TITLE
Skip github actions that haven't been configured

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   publish:
+    if: secrets.CF_PROJECT_NAME_DOCS
     name: Publish to Cloudflare Pages
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build:
+    if: secrets.EXPO_TOKEN
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   publish:
+    if: secrets.CF_PROJECT_NAME
     name: Publish to Cloudflare Pages
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
I noticed github was trying to run a few actions even though I hadn't configured the necessary secrets and vars. I think this update should keep them from running until you have configured your project.