### PR TITLE
Update virtualized list header to be floating

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-module-resolver": "^4.1.0",
     "burnt": "^0.11.7",
     "expo": "^49.0.8",
+    "expo-blur": "^12.4.1",
     "expo-constants": "~14.4.2",
     "expo-dev-client": "~2.4.8",
     "expo-font": "~11.4.0",

--- a/apps/next/next.config.js
+++ b/apps/next/next.config.js
@@ -74,6 +74,7 @@ module.exports = function () {
     },
     transpilePackages: [
       'solito',
+      'expo-blur',
       'expo-linking',
       'expo-constants',
       'expo-modules-core',

--- a/apps/next/pages/_document.tsx
+++ b/apps/next/pages/_document.tsx
@@ -30,7 +30,7 @@ export default class Document extends NextDocument {
         dangerouslySetInnerHTML={{
           __html: Tamagui.getCSS({
             exclude: process.env.NODE_ENV === 'development' ? null : 'design-system',
-          }),
+          }) + '\nbody, #root, #__next { min-height: 100dvh; }\n.h-100dvh { height: 100dvh; }',
         }}
       />,
     ]

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -23,6 +23,7 @@
     "@trpc/next": "^10.38.1",
     "@trpc/react-query": "^10.38.1",
     "burnt": "^0.11.7",
+    "expo-blur": "^12.4.1",
     "expo-constants": "~14.4.2",
     "expo-linking": "~5.0.2",
     "expo-secure-store": "^12.3.1",

--- a/packages/app/provider/theme/index.tsx
+++ b/packages/app/provider/theme/index.tsx
@@ -58,3 +58,11 @@ export const useRootTheme = () => {
   const [currentTheme] = useCurrentTheme()
   return [currentTheme]
 }
+
+// Abridged-interop with tamagui/next useTheme
+// https://tamagui.dev/docs/guides/next-js#themes
+export const useThemeSetting = () => {
+  const [current, set] = useAppTheme()
+  const [resolvedTheme] = useCurrentTheme()
+  return { current, resolvedTheme, set }
+}

--- a/packages/app/provider/theme/index.web.tsx
+++ b/packages/app/provider/theme/index.web.tsx
@@ -5,12 +5,12 @@ export const TamaguiThemeProvider = ({
 }: {
   children: React.ReactNode
 }): React.ReactNode => {
-  const [_, setTheme] = useRootTheme()
+  const [_, setRootTheme] = useRootTheme()
 
   return (
     <NextThemeProvider
       onChangeTheme={(next) => {
-        setTheme(next as ColorScheme)
+        setRootTheme(next as ColorScheme)
       }}
     >
       {children}
@@ -18,4 +18,4 @@ export const TamaguiThemeProvider = ({
   )
 }
 
-export { useRootTheme } from '@tamagui/next-theme'
+export { useRootTheme, useThemeSetting } from '@tamagui/next-theme'

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,7 @@
     "@tamagui/toast": "1.59.5",
     "@tanstack/react-table": "^8.9.3",
     "@tanstack/react-virtual": "3.0.0-beta.54",
+    "expo-blur": "^12.4.1",
     "jotai": "^2.4.1",
     "tamagui": "1.59.5"
   },

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,6 +1,7 @@
 export { config } from './tamagui.config'
 export * from 'tamagui'
 export * from '@tamagui/toast'
+export * from 'expo-blur'
 export * from './MyComponent'
 export * from './CustomToast'
 export * from './list'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       expo:
         specifier: ^49.0.8
         version: 49.0.9(@babel/core@7.22.15)
+      expo-blur:
+        specifier: ^12.4.1
+        version: 12.4.1(expo@49.0.9)
       expo-constants:
         specifier: ~14.4.2
         version: 14.4.2(expo@49.0.9)
@@ -387,6 +390,9 @@ importers:
       burnt:
         specifier: ^0.11.7
         version: 0.11.7(expo@49.0.9)(react-dom@18.2.0)(react-native@0.72.4)(react@18.2.0)
+      expo-blur:
+        specifier: ^12.4.1
+        version: 12.4.1(expo@49.0.9)
       expo-constants:
         specifier: ~14.4.2
         version: 14.4.2(expo@49.0.9)
@@ -445,6 +451,9 @@ importers:
       '@tanstack/react-virtual':
         specifier: 3.0.0-beta.54
         version: 3.0.0-beta.54(react@18.2.0)
+      expo-blur:
+        specifier: ^12.4.1
+        version: 12.4.1(expo@49.0.9)
       jotai:
         specifier: ^2.4.1
         version: 2.4.1(react@18.2.0)
@@ -9705,6 +9714,14 @@ packages:
     transitivePeerDependencies:
       - expo
       - supports-color
+    dev: false
+
+  /expo-blur@12.4.1(expo@49.0.9):
+    resolution: {integrity: sha512-lGN8FS9LuGUlEriULTC62cCWyg5V7zSVQeJ6Duh1wSq8aAETinZ2/7wrT6o+Uhd/XVVxFNON2T25AGCOtMG6ew==}
+    peerDependencies:
+      expo: '*'
+    dependencies:
+      expo: 49.0.9(@babel/core@7.22.15)
     dev: false
 
   /expo-constants@14.4.2(expo@49.0.9):


### PR DESCRIPTION
Adds expo-blur for universal backdrop blur of the header
Add universal useThemeSetting from tamagui/next to get current system theme

Adds h-100dvh css utility class and overrides tamagui default body height
Tamagui currently uses 100vh which is larger than the screen size on mobile.
Dynamic viewport-percentage units were created to address that problem.
https://caniuse.com/viewport-unit-variants
https://www.w3.org/TR/css-values-4/#viewport-variants
