### PR TITLE
[Bug] Fixed web css overflow

### DIFF
--- a/apps/next/pages/_app.tsx
+++ b/apps/next/pages/_app.tsx
@@ -35,6 +35,14 @@ export default trpc.withTRPC(T4App)
 const Metadata = () => (
   <Head>
     <meta name="viewport" content="width=device-width,initial-scale=1" />
+    {/* Next Tamagui CSS fix */}
+    <style>
+      {`
+        body, #root, #__next {
+          min-width: 100% !important;
+        }
+      `}
+    </style>
     {/* Metadata */}
     <title>{title}</title>
     <meta name="description" content={description} />


### PR DESCRIPTION
As discussed already in https://github.com/chen-rn/CUA/pull/86 the default Nextjs styles need to be modified to fix the horizontal overflow on the body.

*Before:*
![2023-09-26 11_51_57-](https://github.com/timothymiller/t4-app/assets/57916483/ab707cb6-5ad2-4f89-94df-edcc243822b3)

*After:*
![2023-09-26 11_51_43-](https://github.com/timothymiller/t4-app/assets/57916483/7456f5a3-7e8c-40ce-834f-0d0a2f8d1205)
