### PR TITLE
fix useUser() not working after kill

### DIFF
--- a/packages/app/utils/supabase/hooks/useAuthRedirect.ts
+++ b/packages/app/utils/supabase/hooks/useAuthRedirect.ts
@@ -16,7 +16,7 @@ export const useAuthRedirect = () => {
           setSession(null)
           router.replace('/')
         }
-        if (event === 'SIGNED_IN') {
+        if (event === 'SIGNED_IN' || event === 'INITIAL_SESSION') {
           setLoading(true)
           setSession(session)
           setLoading(false)


### PR DESCRIPTION
after the app is killed useUser won't work since the is no update on initial load