### PR TITLE
Fix react-native-dotenv by removing typescript casting

### DIFF
--- a/apps/expo/babel.config.js
+++ b/apps/expo/babel.config.js
@@ -9,7 +9,7 @@ module.exports = function (api) {
         {
           moduleName: '@env',
           path: '../../.env',
-          allowlist: ['NEXT_PUBLIC_SUPABASE_URL', 'NEXT_PUBLIC_SUPABASE_ANON_KEY'],
+          allowlist: ['NEXT_PUBLIC_SUPABASE_URL', 'NEXT_PUBLIC_SUPABASE_ANON_KEY', 'NEXT_PUBLIC_APP_URL', 'NEXT_PUBLIC_API_URL', 'NEXT_PUBLIC_SUPPORT_EMAIL'],
           safe: false,
           allowUndefined: true
         }

--- a/packages/app/provider/solito-image/index.tsx
+++ b/packages/app/provider/solito-image/index.tsx
@@ -1,11 +1,11 @@
 import { SolitoImageProvider as SolitoImageProviderOG } from 'solito/image'
 
-const imageURL = process.env.NEXT_PUBLIC_APP_URL as `http:${string}` | `https:${string}`
+const imageURL = process.env.NEXT_PUBLIC_APP_URL
 
 export const SolitoImageProvider = ({
   children,
 }: {
   children: React.ReactNode
 }): React.ReactNode => {
-  return <SolitoImageProviderOG nextJsURL={imageURL}>{children}</SolitoImageProviderOG>
+  return <SolitoImageProviderOG nextJsURL={imageURL as `http:${string}` | `https:${string}`}>{children}</SolitoImageProviderOG>
 }

--- a/packages/app/utils/supabase/client.ts
+++ b/packages/app/utils/supabase/client.ts
@@ -2,8 +2,8 @@ import { createClient } from '@supabase/supabase-js'
 import * as SecureStore from 'expo-secure-store'
 import 'react-native-url-polyfill/auto'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 export const ExpoSecureStoreAdapter = {
   getItem: (key: string) => SecureStore.getItemAsync(key),
@@ -11,7 +11,7 @@ export const ExpoSecureStoreAdapter = {
   removeItem: (key: string) => SecureStore.deleteItemAsync(key),
 }
 
-export const supabase = createClient(supabaseUrl, supabaseKey, {
+export const supabase = createClient(supabaseUrl as string, supabaseKey as string, {
   auth: {
     storage: ExpoSecureStoreAdapter,
     autoRefreshToken: true,


### PR DESCRIPTION
Typescript syntax seems to break react-native-dotenv's ability to replace vars

Also added a few more NEXT_PUBLIC vars to the allowlist.