### PR TITLE
Lucia separate TOTP secret per auth method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,3 @@ DISCORD_CLIENT_SECRET=
 
 # Optional for password reset emails
 RESEND_API_KEY=
-
-# Optional for paassword reset codes / OTP
-# Use the password reset feature locally to generate a secret in the API terminal console
-# Then copy and paste it here in .env.local
-TOTP_SECRET=

--- a/packages/api/migrations/0004_famous_ultimates.sql
+++ b/packages/api/migrations/0004_famous_ultimates.sql
@@ -4,6 +4,10 @@ CREATE TABLE `AuthMethod` (
 	`hashed_password` text,
 	`hash_method` text,
 	`created_at` text DEFAULT CURRENT_TIMESTAMP,
+	`totp_secret` text,
+	`totp_expires` integer,
+	`timeout_until` integer,
+	`timeout_seconds` integer,
 	FOREIGN KEY (`user_id`) REFERENCES `User`(`id`) ON UPDATE no action ON DELETE no action
 );
 --> statement-breakpoint
@@ -14,17 +18,5 @@ CREATE TABLE `Session` (
 	FOREIGN KEY (`user_id`) REFERENCES `User`(`id`) ON UPDATE no action ON DELETE no action
 );
 --> statement-breakpoint
-CREATE TABLE `VerificationCode` (
-	`id` text PRIMARY KEY NOT NULL,
-	`user_id` text NOT NULL,
-	`code` text NOT NULL,
-	`expires` integer NOT NULL,
-	`timeout_until` integer,
-	`timeout_seconds` integer DEFAULT 0 NOT NULL,
-	FOREIGN KEY (`user_id`) REFERENCES `User`(`id`) ON UPDATE no action ON DELETE no action
-);
---> statement-breakpoint
 CREATE INDEX `idx_userKey_userId` ON `AuthMethod` (`user_id`);--> statement-breakpoint
-CREATE INDEX `idx_session_userId` ON `Session` (`user_id`);--> statement-breakpoint
-CREATE UNIQUE INDEX `VerificationCode_user_id_unique` ON `VerificationCode` (`user_id`);--> statement-breakpoint
-CREATE INDEX `idx_verificationCode_userId` ON `VerificationCode` (`user_id`);
+CREATE INDEX `idx_session_userId` ON `Session` (`user_id`);

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -22,7 +22,6 @@ export type Bindings = Env & {
   PUBLIC_SUPPORT_EMAIL: string
   PUBLIC_API_URL: string
   PUBLIC_NATIVE_SCHEME: string
-  TOTP_SECRET: string
   [k: string]: unknown
 }
 

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -31,7 +31,6 @@ migrations_dir = "migrations"
 # - PUBLIC_SUPPORT_EMAIL
 # - PUBLIC_API_URL
 # - PUBLIC_NATIVE_SCHEME
-# - TOTP_SECRET
 #
 # These can be set in the top level .env.local file followed by running `bun i`
 # which will then generate a .dev.vars file used for local cloudflare development.


### PR DESCRIPTION
It was incorrect to reuse a single TOTP secret for resets across all users. This update generates a new secret for each auth method when a code is requested.

This update also removes the VerificationCode table and moves the relevant fields into the AuthMethod table.

Rather than create a new migration, this update edits the existing migration for lucia auth. If you have already run that migration, then connect to your D1 and local sqlite databases and run the following sql:

```sql
DROP TABLE VerificationCode;
ALTER TABLE AuthMethod ADD `totp_secret` text;
ALTER TABLE AuthMethod ADD `totp_expires` integer;
ALTER TABLE AuthMethod ADD `timeout_until` integer;
ALTER TABLE AuthMethod ADD `timeout_seconds` integer;
```