### PR TITLE
[Lucia] Fix to setting cookies

### DIFF
--- a/packages/api/src/auth/user.ts
+++ b/packages/api/src/auth/user.ts
@@ -168,7 +168,7 @@ export const signInWithEmail = async (
     await updatePassword(ctx, email, password)
   }
   const session = await createSession(ctx.auth, authMethod.userId)
-  if (setCookie) {
+  if (!ctx.enableTokens && setCookie) {
     const cookie = ctx.auth.createSessionCookie(session.id)
     setCookie(cookie.serialize())
   }

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -186,7 +186,7 @@ const signInWithAppleIdTokenHandler =
       idTokenClaims: payload,
     })
     const session = await createSession(ctx.auth, user.id)
-    if (ctx.enableTokens && ctx.setCookie) {
+    if (!ctx.enableTokens && ctx.setCookie) {
       ctx.setCookie(ctx.auth.createSessionCookie(session.id).serialize())
     }
     return { session }
@@ -247,7 +247,7 @@ const signInWithEmailCodeHandler =
       console.log('calling update passing and invalidate sessions')
       await ctx.auth.invalidateUserSessions(res.session?.userId)
       const session = await createSession(ctx.auth, res.session?.userId)
-      if (ctx.enableTokens && ctx.setCookie) {
+      if (!ctx.enableTokens && ctx.setCookie) {
         ctx.setCookie(ctx.auth.createSessionCookie(session.id).serialize())
       }
       res.session = session
@@ -342,7 +342,7 @@ export const userRouter = router({
         email: input.email,
       })
       const session = await createSession(ctx.auth, user.id)
-      if (ctx.enableTokens && ctx.setCookie) {
+      if (!ctx.enableTokens && ctx.setCookie) {
         ctx.setCookie(ctx.auth.createSessionCookie(session.id).serialize())
       }
       return { session }


### PR DESCRIPTION
#127 attempted to avoid setting cookies when responding to native clients that are using the `x-enable-tokens` header... but the logic was flipped.