### PR TITLE
Fix error for trpc empty pattern with null and undefined

### DIFF
--- a/packages/app/utils/trpc/patterns.ts
+++ b/packages/app/utils/trpc/patterns.ts
@@ -14,7 +14,9 @@ export const loading = {
 }
 
 export const empty = {
-  data: P.when((data: []) => data.length === 0 || data === null || data === undefined),
+  data: P.when(
+    (data: null | undefined | []) => data === null || data === undefined || data.length === 0,
+  ),
 }
 
 export const success = {


### PR DESCRIPTION
Currently the trpc `empty` pattern only works with arrays and throws an error when null or undefined is passed. Checking the array length after checking null and undefined fixes the error.