### PR TITLE
Fix api dev command for expo development

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {
-    "dev": "wrangler dev",
+    "dev": "wrangler dev --ip 0.0.0.0",
     "generate": "drizzle-kit generate:sqlite --schema=./src/db/schema.ts --out=./migrations",
     "migrate": "wrangler d1 migrations apply production",
     "migrate:local": "wrangler d1 migrations apply production --local",


### PR DESCRIPTION
Due to a [breaking change in wrangler](https://github.com/cloudflare/workers-sdk/pull/4532), the worker dev server is now only available on localhost by default. In order to allow access to the dev server on you machine ip, you need to use the --ip option. This allows simulators and physical devices on your local network to successfully call the dev api.

Fixes: https://github.com/timothymiller/t4-app/issues/155